### PR TITLE
Soft delete

### DIFF
--- a/app/Http/Controllers/SenderIdentityController.php
+++ b/app/Http/Controllers/SenderIdentityController.php
@@ -75,9 +75,8 @@ class SenderIdentityController extends Controller
         return redirect()->route('sender-identity.index')->with('status', sprintf('Identity for %s updated.', $senderIdentity->name));
     }
 
-    public function destroy(Request $request)
+    public function destroy(Request $request, $id)
     {
-        $id = $request->input('senderIdentityId');
         $senderIdentity = SenderIdentity::findOrFail($id);
         if ($senderIdentity) {
             $senderIdentity->delete();

--- a/app/Http/Controllers/SenderIdentityController.php
+++ b/app/Http/Controllers/SenderIdentityController.php
@@ -75,11 +75,10 @@ class SenderIdentityController extends Controller
         return redirect()->route('sender-identity.index')->with('status', sprintf('Identity for %s updated.', $senderIdentity->name));
     }
 
-    public function destroy(Request $request, $id)
+    public function destroy(Request $request,SenderIdentity $sender)
     {
-        $senderIdentity = SenderIdentity::findOrFail($id);
-        if ($senderIdentity) {
-            $senderIdentity->delete();
+        if ($sender) {
+            $sender->delete();
             return back()->with('status', 'Sender-Identity deleted successfully!');
         }
 

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -22,7 +22,7 @@ class Campaign extends Model
 
     public function senderIdentity()
     {
-        return $this->hasOne(SenderIdentity::class, 'id', 'sender_identity_id');
+        return $this->hasOne(SenderIdentity::class, 'id', 'sender_identity_id')->withTrashed();
     }
 
     public function getSenderIdentityNameAttribute()

--- a/app/Models/SenderIdentity.php
+++ b/app/Models/SenderIdentity.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class SenderIdentity extends Model
 {
+    use SoftDeletes;
+
     protected $fillable = ['name', 'email', 'is_default'];
 
     protected function setIsDefaultAttribute($value)

--- a/database/migrations/2020_03_21_141901_create_sender_identities_table.php
+++ b/database/migrations/2020_03_21_141901_create_sender_identities_table.php
@@ -19,6 +19,7 @@ class CreateSenderIdentitiesTable extends Migration
             $table->string('email')->unique();
             $table->boolean('is_default')->default(false);
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/resources/views/sender-identity/index.blade.php
+++ b/resources/views/sender-identity/index.blade.php
@@ -48,8 +48,9 @@
                             <span class="badge badge-primary mr-2">Default</span>
                         @endif
                         <a href="{{route('sender-identity.edit', $identity)}}" class="text-grey-dark mr-2" title="Edit"><i data-feather="edit" class="w-20 h-20"></i></a>
-                        <form action="{{ route('sender-identity.delete',  ['senderIdentityId' => $identity->id]) }}" method="POST">
+                        <form action="{{ route('sender-identity.destroy', $identity->id) }}" method="POST">
                             @csrf
+                            @method('DELETE')
                             <button type="submit" class="btn btn-link text-danger p-0" title="Delete">
                                 <i data-feather="trash-2" class="w-20 h-20"></i>
                             </button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,8 @@ Route::middleware('auth')->group(function () {
     Route::resource('campaign', 'CampaignController')->only(['index', 'create', 'store', 'show']);
     Route::resource('list', 'SubscriptionListController')->except(['show', 'delete']);
     Route::post('list','SubscriptionListController@destroy')->name('list.delete');
-    Route::resource('sender-identity', 'SenderIdentityController')->except(['show']);
+    Route::resource('sender-identity', 'SenderIdentityController')->except(['show', 'destroy']);
+    Route::delete('sender-identity/{sender}', 'SenderIdentityController@destroy')->name('sender-identity.destroy');
     Route::get('subscriber/upload', 'SubscriberController@uploadView')->name('subscriber.upload-view');
     Route::post('subscriber/upload', 'SubscriberController@upload')->name('subscriber.upload');
     Route::resource('subscriber', 'SubscriberController')->except(['show']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,8 +26,7 @@ Route::middleware('auth')->group(function () {
     Route::resource('campaign', 'CampaignController')->only(['index', 'create', 'store', 'show']);
     Route::resource('list', 'SubscriptionListController')->except(['show', 'delete']);
     Route::post('list','SubscriptionListController@destroy')->name('list.delete');
-    Route::resource('sender-identity', 'SenderIdentityController')->except(['show', 'delete']);
-    Route::post('sender-identity/delete','SenderIdentityController@destroy')->name('sender-identity.delete');
+    Route::resource('sender-identity', 'SenderIdentityController')->except(['show']);
     Route::get('subscriber/upload', 'SubscriberController@uploadView')->name('subscriber.upload-view');
     Route::post('subscriber/upload', 'SubscriberController@upload')->name('subscriber.upload');
     Route::resource('subscriber', 'SubscriberController')->except(['show']);


### PR DESCRIPTION
Target #136 

**Description**

Enable soft deletion for sender identities
Once a sender identity is deleted, it should not show up in the list of sender identities
The deleted sender identity should however keep showing up in the campaigns details & campaign listing screens
